### PR TITLE
Freeze @angular/material@2.0.0-beta.7 for now.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@angular/core": "~4.2.0",
     "@angular/forms": "~4.2.0",
     "@angular/http": "~4.2.0",
-    "@angular/material": "^2.0.0-beta.7",
+    "@angular/material": "2.0.0-beta.7",
     "@angular/platform-browser": "~4.2.0",
     "@angular/platform-browser-dynamic": "~4.2.0",
     "@angular/router": "~4.2.0",


### PR DESCRIPTION
Angular's material framework is still getting breaking changes, so the version is frozen to avoid random breakage.